### PR TITLE
Fix code scanning alert no. 2: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/diec/encrypt.py
+++ b/diec/encrypt.py
@@ -1,9 +1,10 @@
-import hashlib
+from argon2 import PasswordHasher
 import random
 import os
 
 def generate_key(passphrase):
-    return hashlib.sha256(passphrase.encode()).digest()
+    ph = PasswordHasher()
+    return ph.hash(passphrase).encode()
 
 def encrypt(data, passphrase):
     key = generate_key(passphrase)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 binaryconvert==2.6
+argon2-cffi==23.1.0


### PR DESCRIPTION
Fixes [https://github.com/Eldritchy/diec/security/code-scanning/2](https://github.com/Eldritchy/diec/security/code-scanning/2)

To fix the problem, we need to replace the use of SHA-256 with a more secure and computationally expensive hashing algorithm suitable for password hashing. Argon2 is a good choice for this purpose. We will use the `argon2-cffi` library to hash the passphrase securely.

Steps to fix the issue:
1. Install the `argon2-cffi` library.
2. Replace the `generate_key` function to use Argon2 for hashing the passphrase.
3. Update the import statements to include the necessary imports from the `argon2-cffi` library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
